### PR TITLE
Add support for yaml specs and using server urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Shelob is a powerful tool designed to test and validate APIs that are defined us
 ## Getting Started
 
 ### Basic usage
- 
+
 ```bash
 go run main.go -spec=**OPENAPI FILE** -url=**TARGET URL**
 ```
+
+Supported OpenAPI specification formats: JSON (.json), YAML (.yaml, .yml)
 
 ### Advanced options
 
@@ -52,7 +54,9 @@ all options:
 
 You can try Shelob using local demo (`demo` directory) or [VAmPI](https://github.com/erev0s/VAmPI).
 
-For local demo just simply run `demo/createDocker.sh`. It uses [Petstore example](https://hub.docker.com/r/swaggerapi/petstore3).The following OpenAPI specification is located in `./demo/openapi.json`
+For local demo just simply run `demo/createDocker.sh`. It uses [Petstore example](https://hub.docker.com/r/swaggerapi/petstore3). The following OpenAPI specification is located in `./demo/openapi.json`
+
+Note: Shelob supports both JSON (.json) and YAML (.yaml, .yml) OpenAPI specification formats.
 
 ## Contributing
 

--- a/cliArgs/cliArgs.go
+++ b/cliArgs/cliArgs.go
@@ -2,15 +2,17 @@ package cliArgs
 
 import (
 	"flag"
+	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
 func ParseCliArgs() (string, string, string, string, string, string, string, bool, time.Duration, []string, bool) {
-	spec := flag.String("spec", "", "openapi file specification (Required)")
-	targetURL := flag.String("url", "", "target URL (Required)")
+	spec := flag.String("spec", "", "OpenAPI file specification (JSON or YAML format, Required)")
+	targetURL := flag.String("url", "", "target URL")
 	username := flag.String("user", "", "username (Basic auth)")
 	password := flag.String("password", "", "password (Basic auth)")
 	apikey := flag.String("apikey", "", "api key for auth")
@@ -22,10 +24,16 @@ func ParseCliArgs() (string, string, string, string, string, string, string, boo
 
 	flag.Parse()
 
-	if *spec == "" || *targetURL == "" {
+	if *spec == "" {
 		flag.PrintDefaults()
-		log.Fatal("Provide OpenAPI file and target URL")
+		log.Fatal("Provide OpenAPI file")
 	}
+
+	if *targetURL == "" {
+		log.Info("No target URL provided via CLI. Will attempt to use server URLs from the OpenAPI specification.")
+	}
+
+	validateSpecFileExtension(*spec)
 
 	re := regexp.MustCompile("/$")
 	if re.FindStringSubmatch(*targetURL) != nil {
@@ -37,4 +45,12 @@ func ParseCliArgs() (string, string, string, string, string, string, string, boo
 	log.Info("[+++] cli arguments are parsed")
 
 	return *spec, *targetURL, *username, *password, *apikey, *token, *outputDir, *detailedOutput, *duration, extraArgs, *enableDebug
+}
+
+// validateSpecFileExtension checks if the spec file has a valid extension
+func validateSpecFileExtension(specFile string) {
+	ext := strings.ToLower(filepath.Ext(specFile))
+	if ext != ".json" && ext != ".yaml" && ext != ".yml" {
+		log.Fatalf("Invalid spec file extension: %s. Supported formats are JSON (.json), YAML (.yaml, .yml)", ext)
+	}
 }

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -17,19 +17,36 @@ func ParseOpenapiSpec(spec string, targetURL string) (*context.Context, *openapi
 		log.Fatal("openapi.go	Failed to load specification from file: ", err)
 	}
 
-	// Fix empty server URLs by using the target URL from command line
-	if openapiData.Servers != nil {
-		for _, server := range openapiData.Servers {
-			if server != nil && server.URL == "" {
-				server.URL = targetURL
+	// Use target URL from CLI if provided, otherwise use server URLs from spec
+	if targetURL != "" {
+		// Override all server URLs with the target URL from command line
+		if openapiData.Servers != nil {
+			log.Infof("Overriding server URLs in spec with CLI target URL: %s", targetURL)
+			for _, server := range openapiData.Servers {
+				if server != nil {
+					server.URL = targetURL
+				}
+			}
+		} else {
+			// If no servers are defined in spec, create a default server with the target URL
+			log.Infof("No servers defined in spec, using CLI target URL: %s", targetURL)
+			openapiData.Servers = openapi3.Servers{
+				&openapi3.Server{
+					URL: targetURL,
+				},
 			}
 		}
 	} else {
-		// If no servers are defined, create a default server with the target URL
-		openapiData.Servers = openapi3.Servers{
-			&openapi3.Server{
-				URL: targetURL,
-			},
+		// Use server URLs from the spec file
+		if openapiData.Servers != nil {
+			log.Infof("Using server URLs from OpenAPI specification:")
+			for i, server := range openapiData.Servers {
+				if server != nil {
+					log.Infof("  Server %d: %s", i+1, server.URL)
+				}
+			}
+		} else {
+			log.Warn("No servers defined in the OpenAPI specification and no target URL provided via CLI")
 		}
 	}
 

--- a/request/request.go
+++ b/request/request.go
@@ -91,23 +91,42 @@ func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers
 			log.Debugf("request.go	Content type: %s, Body payload length: %d", contentType, bodyPayload.Len())
 			security.CreateSecurityParams(operation, securityScheme, *queryParams, headerParams, cookieParams, username, password, apikey, token)
 
-			// Construct the full URL
-			// Avoid double slashes by ensuring basePath ends with / and path starts with /
-			// but only one slash is present in the final path
+			// Construct the full URL and determine path for path parameters
+			// If targetURL is provided via CLI, use it; otherwise use server URL from spec
+			var fullURL string
 			var fullPath string
-			if basePath == "/" {
-				fullPath = path
-			} else {
-				// Ensure basePath ends with / and path doesn't start with /
-				cleanBasePath := strings.TrimSuffix(basePath, "/")
-				cleanPath := strings.TrimPrefix(path, "/")
-				if cleanPath == "" {
-					fullPath = cleanBasePath
+
+			if targetURL != "" {
+				// Avoid double slashes by ensuring basePath ends with / and path starts with /
+				// but only one slash is present in the final path
+				if basePath == "/" {
+					fullPath = path
 				} else {
-					fullPath = cleanBasePath + "/" + cleanPath
+					// Ensure basePath ends with / and path doesn't start with /
+					cleanBasePath := strings.TrimSuffix(basePath, "/")
+					cleanPath := strings.TrimPrefix(path, "/")
+					if cleanPath == "" {
+						fullPath = cleanBasePath
+					} else {
+						fullPath = cleanBasePath + "/" + cleanPath
+					}
+				}
+				fullURL = targetURL + fullPath
+			} else {
+				// Use the server URL from the spec directly
+				if openapiData.Servers != nil && len(openapiData.Servers) > 0 && openapiData.Servers[0] != nil {
+					serverURL := openapiData.Servers[0].URL
+					// Ensure the server URL doesn't end with a slash before appending the path
+					serverURL = strings.TrimSuffix(serverURL, "/")
+					fullURL = serverURL + path
+					// For path parameters, we just use the path part
+					fullPath = path
+				} else {
+					// Fallback if no server URL is defined in the spec
+					log.Errorf("request.go	No server URL defined in spec and no target URL provided via CLI for path: %s", path)
+					continue
 				}
 			}
-			fullURL := targetURL + fullPath
 
 			httpRequest, err := http.NewRequest(method, fullURL, bodyPayload)
 			if err != nil {
@@ -138,8 +157,22 @@ func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers
 				httpRequest.Header.Set("Content-Type", contentType)
 			}
 
+			// Determine the path for routing purposes
+			var routePath string
+			if targetURL != "" {
+				routePath = fullPath
+			} else {
+				// Extract path from the full URL when using server URL from spec
+				parsedURL, err := url.Parse(fullURL)
+				if err != nil {
+					log.Errorf("request.go	Failed to parse full URL for routing: %v", err)
+					continue
+				}
+				routePath = parsedURL.Path
+			}
+
 			// Find and validate route - use original path before parameter substitution
-			originalRequest, err := http.NewRequest(method, httpRequest.URL.Scheme+"://"+httpRequest.URL.Host+fullPath, bodyPayload)
+			originalRequest, err := http.NewRequest(method, httpRequest.URL.Scheme+"://"+httpRequest.URL.Host+routePath, bodyPayload)
 			if err != nil {
 				log.Error("request.go	Failed to create original http request for routing: ", err)
 				continue
@@ -151,17 +184,17 @@ func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers
 				originalRequest.Header[k] = v
 			}
 
-			log.Debugf("request.go	Attempting to find route for %s %s", method, fullPath)
+			log.Debugf("request.go	Attempting to find route for %s %s", method, routePath)
 			route, pathParamsVal, err := (*router).FindRoute(originalRequest)
 			if err != nil {
-				log.Debugf("request.go	Skipping route %s %s: %v", method, fullPath, err)
+				log.Debugf("request.go	Skipping route %s %s: %v", method, routePath, err)
 				continue
 			}
-			log.Debugf("request.go	Route found for %s %s", method, fullPath)
+			log.Debugf("request.go	Route found for %s %s", method, routePath)
 
 			// Don't skip based on validation errors - we want to fuzz even invalid requests
 			requestValidationInput, _ := ValidateRequest(httpRequest, pathParamsVal, queryParams, route, ctx)
-			log.Debugf("request.go	Validation completed for %s %s", method, fullPath)
+			log.Debugf("request.go	Validation completed for %s %s", method, routePath)
 
 			httpRequests = append(httpRequests, httpRequest)
 			requestsValidationInput = append(requestsValidationInput, requestValidationInput)


### PR DESCRIPTION
- You can now provide your OpenAPI specification as a .yml file.
- The url command-line parameter is optional. If omitted, Shelob will use the server.urls defined in the specification file.