### PR TITLE
Refactoring and adding tests

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
+
+const defaultAuthTimeout = 30 * time.Second
 
 type UserItem struct {
 	Username string `json:"username"`
@@ -18,7 +21,6 @@ type UserItem struct {
 	// For example:
 	// SessionMetadata string `json:"session_metadata"`
 }
-
 
 func CreateUser(username, password, url string) []*http.Cookie {
 	return CreateUserWithLoginEndpoint(username, password, url, "/api/v3/user/login")
@@ -34,6 +36,10 @@ func CreateUserWithLoginEndpoint(username, password, url, loginEndpoint string) 
 }
 
 func (testUser *UserItem) getCookies(url, loginEndpoint string) []*http.Cookie {
+	if testUser.Username == "" || testUser.Password == "" || url == "" {
+		return []*http.Cookie{}
+	}
+
 	// Ensure URL has proper scheme
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 		url = "http://" + url
@@ -58,7 +64,8 @@ func (testUser *UserItem) getCookies(url, loginEndpoint string) []*http.Cookie {
 	httpRequest.Header.Set("Accept", "application/json")
 	httpRequest.Header.Set("Content-type", "application/json")
 
-	response, err := http.DefaultClient.Do(httpRequest)
+	client := &http.Client{Timeout: defaultAuthTimeout}
+	response, err := client.Do(httpRequest)
 	if err != nil {
 		log.Warn("auth.go	Failed to make http request for authentication: ", err)
 		// Return empty cookies instead of nil to allow fuzzing to continue without authentication

--- a/bodyParams/bodyParams.go
+++ b/bodyParams/bodyParams.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 
 	"shelob/generateInput"
 
@@ -56,7 +57,11 @@ func CreateBodyData(operation *openapi3.Operation, debugEnabled bool) (string, *
 					goto Exit
 
 				case "application/octet-stream":
-					_, err := bodyParams.Write(bodyData.([]byte))
+					bodyBytes, ok := bodyData.([]byte)
+					if !ok {
+						bodyBytes = []byte(fmt.Sprintf("%v", bodyData))
+					}
+					_, err := bodyParams.Write(bodyBytes)
 					if err != nil {
 						log.Error("bodyParams.go	bodyParams.Write: ", err)
 					}
@@ -64,7 +69,11 @@ func CreateBodyData(operation *openapi3.Operation, debugEnabled bool) (string, *
 					goto Exit
 
 				case "text/plain":
-					_, err := bodyParams.Write(bodyData.([]byte))
+					bodyBytes, ok := bodyData.([]byte)
+					if !ok {
+						bodyBytes = []byte(fmt.Sprintf("%v", bodyData))
+					}
+					_, err := bodyParams.Write(bodyBytes)
 					if err != nil {
 						log.Error("bodyParams.go	bodyParams.Write: ", err)
 					}

--- a/cliArgs/cliArgs.go
+++ b/cliArgs/cliArgs.go
@@ -20,7 +20,7 @@ func ParseCliArgs() (string, string, string, string, string, string, string, boo
 	outputDir := flag.String("output", "fuzzer_output", "output directory")
 	detailedOutput := flag.Bool("detailed", false, "include successful test cases")
 	duration := flag.Duration("duration", 3600000000000, "time duration of fuzzing")
-	enableDebug := flag.Bool("debug", false, "enable debug logs (default: true)")
+	enableDebug := flag.Bool("debug", false, "enable debug logs")
 	rps := flag.Int("rps", 0, "requests per second limit (0 means no limit)")
 
 	flag.Parse()

--- a/demo/createDocker.sh
+++ b/demo/createDocker.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-#Create docker container
-docker run  --ulimit nofile=1024:1024 --name swaggerapi-petstore3 -d -p 8080:8080 swaggerapi/petstore3:1.0.7
+container_name="swaggerapi-petstore3"
+image="swaggerapi/petstore3:1.0.7"
+platform="linux/amd64"
+
+if docker ps -a --format '{{.Names}}' | grep -qx "$container_name"; then
+  docker rm -f "$container_name" >/dev/null
+fi
+
+docker run --platform "$platform" --ulimit nofile=1024:1024 --name "$container_name" -d -p 8080:8080 "$image"

--- a/generateInput/generateInput.go
+++ b/generateInput/generateInput.go
@@ -2,7 +2,6 @@ package generateInput
 
 import (
 	"encoding/base64"
-	"math"
 
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/getkin/kin-openapi/openapi3"
@@ -72,7 +71,7 @@ func CheckNumberFormat(format string) interface{} {
 		return gofakeit.Float64()
 		//        return gofakeit.Float64Range(*min, *max)
 	default:
-		return gofakeit.Number(int(math.Inf(-1)), int(math.Inf(1)))
+		return gofakeit.Float64Range(-1_000_000, 1_000_000)
 	}
 }
 
@@ -85,7 +84,7 @@ func CheckIntegerFormat(format string) interface{} {
 		return gofakeit.Int64()
 		//        return strconv.FormatInt(gofakeit.Int64(), 10)
 	default:
-		return gofakeit.IntRange(int(math.Inf(-1)), int(math.Inf(1)))
+		return gofakeit.IntRange(-1_000_000, 1_000_000)
 		//        return strconv.FormatInt(int64(gofakeit.IntRange(int(math.Inf(-1)), int(math.Inf(1)))), 10)
 	}
 }
@@ -102,10 +101,10 @@ func CheckStringFormat(format string) interface{} {
 
 		// Add support to change password length
 
-		randLen := gofakeit.IntRange(0, 255)
+		randLen := gofakeit.IntRange(1, 255)
 		return gofakeit.Password(true, true, true, true, true, randLen)
 	case "byte":
-		randLen := gofakeit.IntRange(int(math.Inf(-1)), int(math.Inf(1)))
+		randLen := gofakeit.IntRange(1, 1024)
 		randStr := gofakeit.LetterN(uint(randLen))
 		return base64.StdEncoding.EncodeToString([]byte(randStr))
 	case "binary":
@@ -118,13 +117,13 @@ func CheckStringFormat(format string) interface{} {
 	case "uri":
 		return gofakeit.URL()
 	case "hostname":
-		return gofakeit.DomainName() + gofakeit.DomainSuffix()
+		return gofakeit.DomainName() + "." + gofakeit.DomainSuffix()
 	case "ipv4":
 		return gofakeit.IPv4Address()
 	case "ipv6":
 		return gofakeit.IPv6Address()
 	default:
-		randLen := gofakeit.IntRange(int(math.Inf(-1)), int(math.Inf(1)))
+		randLen := gofakeit.IntRange(1, 1024)
 		return gofakeit.LetterN(uint(randLen))
 	}
 }

--- a/generateInput/generateInput_test.go
+++ b/generateInput/generateInput_test.go
@@ -1,0 +1,41 @@
+package generateInput
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestCheckStringFormatByteHasBoundedPositiveLength(t *testing.T) {
+	value, ok := CheckStringFormat("byte").(string)
+	if !ok {
+		t.Fatalf("CheckStringFormat(byte) returned %T, want string", value)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		t.Fatalf("byte format returned invalid base64: %v", err)
+	}
+	if len(decoded) == 0 || len(decoded) > 1024 {
+		t.Fatalf("decoded byte length = %d, want 1..1024", len(decoded))
+	}
+}
+
+func TestCheckStringFormatDefaultHasBoundedPositiveLength(t *testing.T) {
+	value, ok := CheckStringFormat("unknown-format").(string)
+	if !ok {
+		t.Fatalf("CheckStringFormat(default) returned %T, want string", value)
+	}
+	if len(value) == 0 || len(value) > 1024 {
+		t.Fatalf("default string length = %d, want 1..1024", len(value))
+	}
+}
+
+func TestCheckIntegerFormatDefaultIsBounded(t *testing.T) {
+	value, ok := CheckIntegerFormat("").(int)
+	if !ok {
+		t.Fatalf("CheckIntegerFormat(default) returned %T, want int", value)
+	}
+	if value < -1_000_000 || value > 1_000_000 {
+		t.Fatalf("integer = %d, want within [-1000000, 1000000]", value)
+	}
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -47,81 +47,51 @@ func CreateDir(outputDir string) {
 }
 
 func WrapCrash(filename string, response *http.Response, requestValidationError error, requestBody []byte, responseBody []byte, errval error) {
-	log.SetFormatter(&logrus.JSONFormatter{
-		PrettyPrint:       true,
-		DisableHTMLEscape: true,
-	})
-
-	// Create a unique filename with timestamp to avoid appending to the same file
-	timestamp := time.Now().Format("20060102_150405_000") // Format: YYYYMMDD_HHMMSS_mmm
-
-	// Separate directory and base filename to preserve directory structure
-	outputDir := filepath.Dir(filename)
-	baseFilename := filepath.Base(filename)
-	sanitizedBase := sanitizeFilename(baseFilename) // Only sanitize the base name
-	uniqueFilename := filepath.Join(outputDir, sanitizedBase + "_" + timestamp + ".json")
-
-	file, err := os.OpenFile(uniqueFilename, os.O_CREATE|os.O_WRONLY, 0o644)
-
-	if err == nil {
-		log.SetOutput(file)
-	} else {
-		log.Warn("logging.go	Failed to log to the file, using default stderr")
-	}
-
-	// defer file.Close()
-
-	log.WithFields(logrus.Fields{
-		"raw_path":            response.Request.URL.RawPath,
-		"method":              response.Request.Method,
-		"status":              response.Status,
-		"path":                response.Request.URL.Path,
-		"query":               response.Request.URL.RawQuery,
-		"headers":             response.Request.Header,
-		"cookies":             response.Request.Cookies(),
-		"body_payload":        string(requestBody),
-		"request_validation":  requestValidationError,
-		"response_body":       string(responseBody),
-		"response_validation": errval,
-	}).Error("Crash")
+	writeReport(filename, response, requestValidationError, requestBody, responseBody, errval, logrus.ErrorLevel, "Crash")
 }
 
 func WrapTest(filename string, response *http.Response, requestValidationError error, requestBody []byte, responseBody []byte, errval error) {
-	log.SetFormatter(&logrus.JSONFormatter{
+	writeReport(filename, response, requestValidationError, requestBody, responseBody, errval, logrus.InfoLevel, "Test")
+}
+
+func writeReport(filename string, response *http.Response, requestValidationError error, requestBody []byte, responseBody []byte, errval error, level logrus.Level, message string) {
+	reportLog := logrus.New()
+	reportLog.SetFormatter(&logrus.JSONFormatter{
 		PrettyPrint:       true,
 		DisableHTMLEscape: true,
 	})
-
-	// Create a unique filename with timestamp to avoid appending to the same file
-	timestamp := time.Now().Format("20060102_150405_000") // Format: YYYYMMDD_HHMMSS_mmm
 
 	// Separate directory and base filename to preserve directory structure
 	outputDir := filepath.Dir(filename)
 	baseFilename := filepath.Base(filename)
 	sanitizedBase := sanitizeFilename(baseFilename) // Only sanitize the base name
-	uniqueFilename := filepath.Join(outputDir, sanitizedBase + "_" + timestamp + ".json")
-
-	file, err := os.OpenFile(uniqueFilename, os.O_CREATE|os.O_WRONLY, 0o644)
-
-	if err == nil {
-		log.SetOutput(file)
-	} else {
-		log.Warn("logging.go	Failed to log to the file, using default stderr")
+	if sanitizedBase == "" {
+		sanitizedBase = "report"
 	}
 
-	// defer file.Close()
+	timestamp := time.Now().Format("20060102_150405")
+	file, err := os.CreateTemp(outputDir, sanitizedBase+"_"+timestamp+"_*.json")
+	if err != nil {
+		log.Debug("logging.go	Failed to log to the file: ", err)
+		return
+	}
+	defer file.Close()
+	reportLog.SetOutput(file)
 
-	log.WithFields(logrus.Fields{
+	entry := reportLog.WithFields(logrus.Fields{
 		"raw_path":            response.Request.URL.RawPath,
 		"method":              response.Request.Method,
 		"status":              response.Status,
 		"path":                response.Request.URL.Path,
 		"query":               response.Request.URL.RawQuery,
 		"headers":             response.Request.Header,
+		"response_headers":    response.Header,
 		"cookies":             response.Request.Cookies(),
 		"body_payload":        string(requestBody),
 		"request_validation":  requestValidationError,
 		"response_body":       string(responseBody),
 		"response_validation": errval,
-	}).Info("Test")
+	})
+
+	entry.Log(level, message)
 }

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func TestWrapCrashCreatesUniqueFilesForRepeatedReports(t *testing.T) {
+	outputDir := t.TempDir()
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/api/v3/user/login", nil)
+	response := &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Request:    request,
+	}
+
+	filename := filepath.Join(outputDir, "example_api_v3_user_login")
+	WrapCrash(filename, response, nil, nil, []byte(`{}`), assertErr("first"))
+	WrapCrash(filename, response, nil, nil, []byte(`{}`), assertErr("second"))
+
+	files, err := filepath.Glob(filepath.Join(outputDir, "example_api_v3_user_login_*.json"))
+	if err != nil {
+		t.Fatalf("glob failed: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("created %d report files, want 2", len(files))
+	}
+}
+
+type assertErr string
+
+func (err assertErr) Error() string {
+	return string(err)
+}

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -2,6 +2,8 @@ package openapi
 
 import (
 	"context"
+	"net/url"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/routers"
@@ -17,25 +19,8 @@ func ParseOpenapiSpec(spec string, targetURL string) (*context.Context, *openapi
 		log.Fatal("openapi.go	Failed to load specification from file: ", err)
 	}
 
-	// Use target URL from CLI if provided, otherwise use server URLs from spec
 	if targetURL != "" {
-		// Override all server URLs with the target URL from command line
-		if openapiData.Servers != nil {
-			log.Infof("Overriding server URLs in spec with CLI target URL: %s", targetURL)
-			for _, server := range openapiData.Servers {
-				if server != nil {
-					server.URL = targetURL
-				}
-			}
-		} else {
-			// If no servers are defined in spec, create a default server with the target URL
-			log.Infof("No servers defined in spec, using CLI target URL: %s", targetURL)
-			openapiData.Servers = openapi3.Servers{
-				&openapi3.Server{
-					URL: targetURL,
-				},
-			}
-		}
+		normalizeServersForTarget(openapiData, targetURL)
 	} else {
 		// Use server URLs from the spec file
 		if openapiData.Servers != nil {
@@ -96,4 +81,66 @@ func ParseOpenapiSpec(spec string, targetURL string) (*context.Context, *openapi
 	log.Info("[+++] OpenAPI spec are parsed ok")
 
 	return &ctx, openapiData, &router
+}
+
+func normalizeServersForTarget(openapiData *openapi3.T, targetURL string) {
+	targetPath := "/"
+	parsedTargetURL, err := url.Parse(normalizeURL(targetURL))
+	if err == nil && parsedTargetURL.Path != "" {
+		targetPath = cleanServerPath(parsedTargetURL.Path)
+	}
+
+	// A CLI URL with a path is an explicit base-path override. A host-only CLI
+	// URL keeps the base path from the OpenAPI servers section.
+	if targetPath != "/" {
+		log.Infof("Overriding server base paths in spec with CLI target URL path: %s", targetPath)
+		openapiData.Servers = openapi3.Servers{
+			&openapi3.Server{URL: targetPath},
+		}
+		return
+	}
+
+	if openapiData.Servers == nil || len(openapiData.Servers) == 0 {
+		log.Infof("No servers defined in spec, using CLI target URL: %s", targetURL)
+		openapiData.Servers = openapi3.Servers{
+			&openapi3.Server{URL: "/"},
+		}
+		return
+	}
+
+	log.Infof("Using CLI target host with server base paths from the OpenAPI specification")
+	for _, server := range openapiData.Servers {
+		if server == nil {
+			continue
+		}
+
+		serverPath := "/"
+		if server.URL != "" {
+			parsedServerURL, err := url.Parse(server.URL)
+			if err == nil && parsedServerURL.Path != "" {
+				serverPath = cleanServerPath(parsedServerURL.Path)
+			}
+		}
+		server.URL = serverPath
+	}
+}
+
+func normalizeURL(rawURL string) string {
+	if rawURL == "" || strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
+		return rawURL
+	}
+	return "http://" + rawURL
+}
+
+func cleanServerPath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if len(path) > 1 && strings.HasSuffix(path, "/") {
+		path = strings.TrimSuffix(path, "/")
+	}
+	return path
 }

--- a/openapi/openapi_test.go
+++ b/openapi/openapi_test.go
@@ -1,0 +1,46 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestNormalizeServersForTargetReplacesEmptyServerURL(t *testing.T) {
+	doc := &openapi3.T{
+		Servers: openapi3.Servers{&openapi3.Server{URL: ""}},
+	}
+
+	normalizeServersForTarget(doc, "http://127.0.0.1:5001")
+
+	if len(doc.Servers) != 1 {
+		t.Fatalf("servers length = %d, want 1", len(doc.Servers))
+	}
+	if doc.Servers[0].URL != "/" {
+		t.Fatalf("server URL = %q, want %q", doc.Servers[0].URL, "/")
+	}
+}
+
+func TestNormalizeServersForTargetKeepsSpecBasePath(t *testing.T) {
+	doc := &openapi3.T{
+		Servers: openapi3.Servers{&openapi3.Server{URL: "/api/v3"}},
+	}
+
+	normalizeServersForTarget(doc, "http://127.0.0.1:8080")
+
+	if doc.Servers[0].URL != "/api/v3" {
+		t.Fatalf("server URL = %q, want %q", doc.Servers[0].URL, "/api/v3")
+	}
+}
+
+func TestNormalizeServersForTargetUsesCLIPathOverride(t *testing.T) {
+	doc := &openapi3.T{
+		Servers: openapi3.Servers{&openapi3.Server{URL: "/api/v3"}},
+	}
+
+	normalizeServersForTarget(doc, "http://127.0.0.1:8080/custom")
+
+	if doc.Servers[0].URL != "/custom" {
+		t.Fatalf("server URL = %q, want %q", doc.Servers[0].URL, "/custom")
+	}
+}

--- a/request/request.go
+++ b/request/request.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -17,46 +18,24 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers.Router, targetURL string, authCookies []*http.Cookie, username, password, apikey, token string, extraArgs []string, debugEnabled bool) ([]*http.Request, []*openapi3filter.RequestValidationInput, []*error) {
+func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers.Router, targetURL string, authCookies []*http.Cookie, username, password, apikey, token string, extraArgs []string, debugEnabled bool) ([]*http.Request, []*openapi3filter.RequestValidationInput, []error) {
 	var (
 		httpRequests            []*http.Request
 		requestsValidationInput []*openapi3filter.RequestValidationInput
-		requestsValidationError []*error
+		requestsValidationError []error
 	)
 
 	log.Debugf("request.go	Starting request creation for URL: %s", targetURL)
 	log.Debugf("request.go	Number of auth cookies: %d", len(authCookies))
 
-	// Get the base path from the OpenAPI spec
-	var basePath string
+	serverURL := ""
 	if openapiData.Servers != nil && len(openapiData.Servers) > 0 && openapiData.Servers[0] != nil {
-		serverURL := openapiData.Servers[0].URL
-		parsedURL, err := url.Parse(serverURL)
-		if err != nil {
-			log.Errorf("request.go	Failed to parse server URL %s: %v", serverURL, err)
-			basePath = "/"
-		} else {
-			basePath = parsedURL.Path
-			if basePath == "" {
-				basePath = "/"
-			}
-		}
+		serverURL = openapiData.Servers[0].URL
 	} else {
 		log.Warn("request.go	No servers defined in OpenAPI spec, using root path")
-		basePath = "/"
 	}
 
-	// Ensure base path starts with /
-	if !strings.HasPrefix(basePath, "/") {
-		basePath = "/" + basePath
-	}
-
-	// Ensure base path doesn't end with / unless it's just "/"
-	if len(basePath) > 1 && strings.HasSuffix(basePath, "/") {
-		basePath = strings.TrimSuffix(basePath, "/")
-	}
-
-	log.Debugf("request.go	Base path: %s", basePath)
+	log.Debugf("request.go	Server URL from spec: %s", serverURL)
 	log.Debugf("request.go	Target URL: %s", targetURL)
 
 	// Add global security feature here
@@ -91,41 +70,10 @@ func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers
 			log.Debugf("request.go	Content type: %s, Body payload length: %d", contentType, bodyPayload.Len())
 			security.CreateSecurityParams(operation, securityScheme, *queryParams, headerParams, cookieParams, username, password, apikey, token)
 
-			// Construct the full URL and determine path for path parameters
-			// If targetURL is provided via CLI, use it; otherwise use server URL from spec
-			var fullURL string
-			var fullPath string
-
-			if targetURL != "" {
-				// Avoid double slashes by ensuring basePath ends with / and path starts with /
-				// but only one slash is present in the final path
-				if basePath == "/" {
-					fullPath = path
-				} else {
-					// Ensure basePath ends with / and path doesn't start with /
-					cleanBasePath := strings.TrimSuffix(basePath, "/")
-					cleanPath := strings.TrimPrefix(path, "/")
-					if cleanPath == "" {
-						fullPath = cleanBasePath
-					} else {
-						fullPath = cleanBasePath + "/" + cleanPath
-					}
-				}
-				fullURL = targetURL + fullPath
-			} else {
-				// Use the server URL from the spec directly
-				if openapiData.Servers != nil && len(openapiData.Servers) > 0 && openapiData.Servers[0] != nil {
-					serverURL := openapiData.Servers[0].URL
-					// Ensure the server URL doesn't end with a slash before appending the path
-					serverURL = strings.TrimSuffix(serverURL, "/")
-					fullURL = serverURL + path
-					// For path parameters, we just use the path part
-					fullPath = path
-				} else {
-					// Fallback if no server URL is defined in the spec
-					log.Errorf("request.go	No server URL defined in spec and no target URL provided via CLI for path: %s", path)
-					continue
-				}
+			fullURL, fullPath, routePath, err := buildOperationURL(targetURL, serverURL, path)
+			if err != nil {
+				log.Errorf("request.go	Failed to build request URL for path %s: %v", path, err)
+				continue
 			}
 
 			httpRequest, err := http.NewRequest(method, fullURL, bodyPayload)
@@ -157,20 +105,6 @@ func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers
 				httpRequest.Header.Set("Content-Type", contentType)
 			}
 
-			// Determine the path for routing purposes
-			var routePath string
-			if targetURL != "" {
-				routePath = fullPath
-			} else {
-				// Extract path from the full URL when using server URL from spec
-				parsedURL, err := url.Parse(fullURL)
-				if err != nil {
-					log.Errorf("request.go	Failed to parse full URL for routing: %v", err)
-					continue
-				}
-				routePath = parsedURL.Path
-			}
-
 			// Find and validate route - use original path before parameter substitution
 			originalRequest, err := http.NewRequest(method, httpRequest.URL.Scheme+"://"+httpRequest.URL.Host+routePath, bodyPayload)
 			if err != nil {
@@ -193,12 +127,12 @@ func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers
 			log.Debugf("request.go	Route found for %s %s", method, routePath)
 
 			// Don't skip based on validation errors - we want to fuzz even invalid requests
-			requestValidationInput, _ := ValidateRequest(httpRequest, pathParamsVal, queryParams, route, ctx)
+			requestValidationInput, validationErr := ValidateRequest(httpRequest, pathParamsVal, queryParams, route, ctx)
 			log.Debugf("request.go	Validation completed for %s %s", method, routePath)
 
 			httpRequests = append(httpRequests, httpRequest)
 			requestsValidationInput = append(requestsValidationInput, requestValidationInput)
-			requestsValidationError = append(requestsValidationError, &err)
+			requestsValidationError = append(requestsValidationError, validationErr)
 			log.Debugf("request.go	Appended request, total requests now: %d", len(httpRequests))
 		}
 	}
@@ -206,6 +140,95 @@ func CreateRequest(ctx context.Context, openapiData *openapi3.T, router *routers
 	log.Debugf("request.go	Total requests created: %d", len(httpRequests))
 
 	return httpRequests, requestsValidationInput, requestsValidationError
+}
+
+func buildOperationURL(targetURL, serverURL, operationPath string) (string, string, string, error) {
+	serverBasePath, err := pathFromServerURL(serverURL)
+	if err != nil {
+		return "", "", "", err
+	}
+	routePath := joinURLPath(serverBasePath, operationPath)
+
+	if targetURL != "" {
+		normalizedTargetURL := normalizeURL(targetURL)
+		parsedTargetURL, err := url.Parse(normalizedTargetURL)
+		if err != nil {
+			return "", "", "", err
+		}
+		if parsedTargetURL.Scheme == "" || parsedTargetURL.Host == "" {
+			return "", "", "", fmt.Errorf("target URL must include host: %s", targetURL)
+		}
+
+		targetBasePath := cleanURLPath(parsedTargetURL.Path)
+		if targetBasePath == "/" {
+			targetBasePath = serverBasePath
+		}
+
+		fullPath := joinURLPath(targetBasePath, operationPath)
+		fullURL := parsedTargetURL.Scheme + "://" + parsedTargetURL.Host + fullPath
+		return fullURL, fullPath, routePath, nil
+	}
+
+	if serverURL == "" {
+		return "", "", "", fmt.Errorf("no server URL defined in spec and no target URL provided via CLI")
+	}
+
+	normalizedServerURL := normalizeURL(serverURL)
+	parsedServerURL, err := url.Parse(normalizedServerURL)
+	if err != nil {
+		return "", "", "", err
+	}
+	if parsedServerURL.Scheme == "" || parsedServerURL.Host == "" {
+		return "", "", "", fmt.Errorf("server URL is relative, provide -url for target host: %s", serverURL)
+	}
+
+	fullURL := parsedServerURL.Scheme + "://" + parsedServerURL.Host + routePath
+	return fullURL, routePath, routePath, nil
+}
+
+func pathFromServerURL(serverURL string) (string, error) {
+	if serverURL == "" {
+		return "/", nil
+	}
+
+	parsedServerURL, err := url.Parse(serverURL)
+	if err != nil {
+		return "", err
+	}
+
+	return cleanURLPath(parsedServerURL.Path), nil
+}
+
+func cleanURLPath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if len(path) > 1 && strings.HasSuffix(path, "/") {
+		path = strings.TrimSuffix(path, "/")
+	}
+	return path
+}
+
+func joinURLPath(basePath, operationPath string) string {
+	basePath = cleanURLPath(basePath)
+	operationPath = cleanURLPath(operationPath)
+	if basePath == "/" {
+		return operationPath
+	}
+	if operationPath == "/" {
+		return basePath
+	}
+	return basePath + "/" + strings.TrimPrefix(operationPath, "/")
+}
+
+func normalizeURL(rawURL string) string {
+	if rawURL == "" || strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
+		return rawURL
+	}
+	return "http://" + rawURL
 }
 
 func ValidateRequest(httpRequest *http.Request, pathParams map[string]string, queryParams *url.Values, route *routers.Route, ctx context.Context) (*openapi3filter.RequestValidationInput, error) {
@@ -230,11 +253,19 @@ func ValidateRequest(httpRequest *http.Request, pathParams map[string]string, qu
 
 	// Try to validate the request, but don't fail if validation fails during fuzzing
 	validationErr := openapi3filter.ValidateRequest(ctx, requestValidationInput)
+	if httpRequest.GetBody != nil {
+		body, err := httpRequest.GetBody()
+		if err != nil {
+			log.Debugf("request.go	Failed to reset request body after validation: %v", err)
+		} else {
+			httpRequest.Body = body
+		}
+	}
 	if validationErr != nil {
 		// Log the validation error but continue anyway during fuzzing
 		log.Debugf("request.go	Validation error: %v", validationErr)
 		// Return the input even if validation failed, so requests can still be sent
-		return requestValidationInput, nil
+		return requestValidationInput, validationErr
 	}
 
 	return requestValidationInput, nil

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -1,0 +1,61 @@
+package request
+
+import "testing"
+
+func TestBuildOperationURLUsesSpecBasePathWithHostOnlyTarget(t *testing.T) {
+	fullURL, fullPath, routePath, err := buildOperationURL("http://localhost:8080", "/api/v3", "/pet")
+	if err != nil {
+		t.Fatalf("buildOperationURL returned error: %v", err)
+	}
+
+	if fullURL != "http://localhost:8080/api/v3/pet" {
+		t.Fatalf("fullURL = %q, want %q", fullURL, "http://localhost:8080/api/v3/pet")
+	}
+	if fullPath != "/api/v3/pet" {
+		t.Fatalf("fullPath = %q, want %q", fullPath, "/api/v3/pet")
+	}
+	if routePath != "/api/v3/pet" {
+		t.Fatalf("routePath = %q, want %q", routePath, "/api/v3/pet")
+	}
+}
+
+func TestBuildOperationURLUsesTargetBasePathWhenProvided(t *testing.T) {
+	fullURL, fullPath, routePath, err := buildOperationURL("http://localhost:8080/custom", "/custom", "/pet")
+	if err != nil {
+		t.Fatalf("buildOperationURL returned error: %v", err)
+	}
+
+	if fullURL != "http://localhost:8080/custom/pet" {
+		t.Fatalf("fullURL = %q, want %q", fullURL, "http://localhost:8080/custom/pet")
+	}
+	if fullPath != "/custom/pet" {
+		t.Fatalf("fullPath = %q, want %q", fullPath, "/custom/pet")
+	}
+	if routePath != "/custom/pet" {
+		t.Fatalf("routePath = %q, want %q", routePath, "/custom/pet")
+	}
+}
+
+func TestBuildOperationURLUsesAbsoluteServerWhenTargetIsEmpty(t *testing.T) {
+	fullURL, fullPath, routePath, err := buildOperationURL("", "https://api.example.com/v1", "/pet")
+	if err != nil {
+		t.Fatalf("buildOperationURL returned error: %v", err)
+	}
+
+	if fullURL != "https://api.example.com/v1/pet" {
+		t.Fatalf("fullURL = %q, want %q", fullURL, "https://api.example.com/v1/pet")
+	}
+	if fullPath != "/v1/pet" {
+		t.Fatalf("fullPath = %q, want %q", fullPath, "/v1/pet")
+	}
+	if routePath != "/v1/pet" {
+		t.Fatalf("routePath = %q, want %q", routePath, "/v1/pet")
+	}
+}
+
+func TestBuildOperationURLRequiresTargetForRelativeServer(t *testing.T) {
+	_, _, _, err := buildOperationURL("", "/api/v3", "/pet")
+	if err == nil {
+		t.Fatal("buildOperationURL returned nil error for relative server without target")
+	}
+}

--- a/response/response.go
+++ b/response/response.go
@@ -12,7 +12,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func ParseResponse(ctx context.Context, httpRequests []*http.Request, requestsValidationInput []*openapi3filter.RequestValidationInput, requestsValidationError []*error, outputDir string, detailed bool, rps int) {
+const defaultHTTPTimeout = 30 * time.Second
+
+func ParseResponse(ctx context.Context, httpRequests []*http.Request, requestsValidationInput []*openapi3filter.RequestValidationInput, requestsValidationError []error, outputDir string, detailed bool, rps int) {
 	logging.CreateDir(outputDir)
 	log.Debugf("response.go	Total requests to send: %d", len(httpRequests))
 
@@ -20,6 +22,8 @@ func ParseResponse(ctx context.Context, httpRequests []*http.Request, requestsVa
 		log.Debugf("response.go	No requests to send - this might be the issue!")
 		return
 	}
+
+	client := &http.Client{Timeout: defaultHTTPTimeout}
 
 	// Initialize rate limiter if RPS is set
 	var rateLimiter *time.Ticker
@@ -37,7 +41,6 @@ func ParseResponse(ctx context.Context, httpRequests []*http.Request, requestsVa
 		}
 		log.Debugf("response.go	About to send request: %s %s", httpRequests[idx].Method, httpRequests[idx].URL.String())
 		func() {
-			client := &http.Client{}
 			// We need to get the body again for logging purposes, but don't consume it unnecessarily
 			// Just get the body for logging if needed
 			var requestBody []byte
@@ -87,42 +90,35 @@ func ParseResponse(ctx context.Context, httpRequests []*http.Request, requestsVa
 				log.Error("response.go	Failed to read response body: ", err)
 			}
 
-			responseHeaders := httpRequests[idx].Header.Clone()
 			responseCode := httpResponse.StatusCode
 
 			log.Debugf("response.go	Response received: %d for %s %s", responseCode, httpRequests[idx].Method, httpRequests[idx].URL.String())
 
-			err = ValidateResponse(ctx, requestsValidationInput[idx], responseCode, &responseHeaders)
+			if idx >= len(requestsValidationInput) {
+				log.Errorf("response.go	Missing request validation input for request index %d", idx)
+				return
+			}
+
+			err = ValidateResponse(ctx, requestsValidationInput[idx], responseCode, httpResponse.Header, responseBody)
 
 			if err != nil {
 				log.Debugf("response.go	Validation error for %s %s: %v", httpRequests[idx].Method, httpRequests[idx].URL.String(), err)
 				// Create filename with host:port and path to better identify vulnerable sites
-				hostPort := strings.ReplaceAll(httpRequests[idx].URL.Host, ":", "_") // Replace : with _ to avoid filesystem issues
-				pathPart := strings.ReplaceAll(httpRequests[idx].URL.RawPath, "/", "_")
-				if pathPart == "" || pathPart == "_" {
-					pathPart = "_root" // Use _root for root path to make it more descriptive
-				}
-				logging.WrapCrash(outputDir+"/"+hostPort+pathPart, httpResponse, *requestsValidationError[idx], requestBody, responseBody, err)
+				logging.WrapCrash(outputDir+"/"+reportName(httpRequests[idx]), httpResponse, validationErrorAt(requestsValidationError, idx), requestBody, responseBody, err)
 			} else if detailed {
 				log.Debugf("response.go	Validation passed for %s %s", httpRequests[idx].Method, httpRequests[idx].URL.String())
 				// Create filename with host:port and path to better identify vulnerable sites
-				hostPort := strings.ReplaceAll(httpRequests[idx].URL.Host, ":", "_") // Replace : with _ to avoid filesystem issues
-				pathPart := strings.ReplaceAll(httpRequests[idx].URL.RawPath, "/", "_")
-				if pathPart == "" || pathPart == "_" {
-					pathPart = "_root" // Use _root for root path to make it more descriptive
-				}
-				logging.WrapTest(outputDir+"/"+hostPort+pathPart, httpResponse, *requestsValidationError[idx], requestBody, responseBody, err)
+				logging.WrapTest(outputDir+"/"+reportName(httpRequests[idx]), httpResponse, validationErrorAt(requestsValidationError, idx), requestBody, responseBody, err)
 			}
 		}()
 	}
 }
 
-func ValidateResponse(ctx context.Context, requestValidationInput *openapi3filter.RequestValidationInput, responseCode int, responseHeaders *http.Header) error {
-	responseBody := []byte(`{}`)
+func ValidateResponse(ctx context.Context, requestValidationInput *openapi3filter.RequestValidationInput, responseCode int, responseHeaders http.Header, responseBody []byte) error {
 	responseValidationInput := &openapi3filter.ResponseValidationInput{
 		RequestValidationInput: requestValidationInput,
 		Status:                 responseCode,
-		Header:                 *responseHeaders,
+		Header:                 responseHeaders,
 		Options: &openapi3filter.Options{
 			ExcludeResponseBody:   false,
 			IncludeResponseStatus: true,
@@ -132,4 +128,20 @@ func ValidateResponse(ctx context.Context, requestValidationInput *openapi3filte
 	responseValidationInput.SetBodyBytes(responseBody)
 	err := openapi3filter.ValidateResponse(ctx, responseValidationInput)
 	return err
+}
+
+func reportName(request *http.Request) string {
+	hostPort := strings.ReplaceAll(request.URL.Host, ":", "_")
+	pathPart := strings.ReplaceAll(request.URL.EscapedPath(), "/", "_")
+	if pathPart == "" || pathPart == "_" {
+		pathPart = "_root"
+	}
+	return hostPort + pathPart
+}
+
+func validationErrorAt(errors []error, idx int) error {
+	if idx >= len(errors) {
+		return nil
+	}
+	return errors[idx]
 }

--- a/response/response_test.go
+++ b/response/response_test.go
@@ -1,0 +1,61 @@
+package response
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+)
+
+func TestValidateResponseUsesActualResponseBody(t *testing.T) {
+	ctx := context.Background()
+	operation := openapi3.NewOperation()
+	responseSchema := openapi3.NewObjectSchema().
+		WithProperty("name", openapi3.NewStringSchema()).
+		WithRequired([]string{"name"})
+	operation.AddResponse(200, openapi3.NewResponse().WithDescription("ok").WithJSONSchema(responseSchema))
+
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "test", Version: "1.0.0"},
+		Servers: openapi3.Servers{&openapi3.Server{URL: "http://example.com"}},
+		Paths: openapi3.NewPaths(
+			openapi3.WithPath("/pet", &openapi3.PathItem{Get: operation}),
+		),
+	}
+	if err := doc.Validate(ctx); err != nil {
+		t.Fatalf("spec validation failed: %v", err)
+	}
+
+	router, err := gorillamux.NewRouter(doc)
+	if err != nil {
+		t.Fatalf("router creation failed: %v", err)
+	}
+
+	request, err := http.NewRequest(http.MethodGet, "http://example.com/pet", nil)
+	if err != nil {
+		t.Fatalf("request creation failed: %v", err)
+	}
+	route, pathParams, err := router.FindRoute(request)
+	if err != nil {
+		t.Fatalf("route lookup failed: %v", err)
+	}
+
+	validationInput := &openapi3filter.RequestValidationInput{
+		Request:    request,
+		PathParams: pathParams,
+		Route:      route,
+	}
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+
+	if err := ValidateResponse(ctx, validationInput, http.StatusOK, headers, []byte(`{"name":"fluffy"}`)); err != nil {
+		t.Fatalf("ValidateResponse returned error for valid body: %v", err)
+	}
+
+	if err := ValidateResponse(ctx, validationInput, http.StatusOK, headers, []byte(`{}`)); err == nil {
+		t.Fatal("ValidateResponse returned nil error for invalid body")
+	}
+}

--- a/run/run.go
+++ b/run/run.go
@@ -17,13 +17,15 @@ import (
 func Run() {
 	Start := time.Now()
 
+	log.SetLevel(log.FatalLevel)
+
 	Spec, TargetURL, UserName, Password, ApiKey, Token, OutputDir, Detailed, Duration, ExtraArgs, EnableDebug, RPS := cliArgs.ParseCliArgs()
 
 	// Set log level based on the debug flag
 	if EnableDebug {
 		log.SetLevel(log.DebugLevel)
 	} else {
-		log.SetLevel(log.InfoLevel)
+		log.SetLevel(log.FatalLevel)
 	}
 
 	Context, OpenapiData, Router := openapi.ParseOpenapiSpec(Spec, TargetURL)


### PR DESCRIPTION
  - Fixed response validation to use actual response bodies and response headers.
  - Fixed OpenAPI server/base path handling, including empty `servers[].url` values when `-url` is
  provided.
  - Added HTTP timeouts for fuzzing and authentication requests.
  - Fixed request validation error reporting and reset request bodies after validation.
  - Improved report file generation to avoid filename collisions and prevent JSON reports from leaking
  to stderr.
  - Hardened random input generation against invalid or unbounded lengths.
  - Made the Petstore demo Docker script idempotent and explicit about platform.
  - Added unit tests for URL building, OpenAPI server normalization, response validation, report file
  creation, and bounded input generation.